### PR TITLE
[BUGFIX] Fixes incorrect typing on txnpostburn type on txnsign, added missing 'add' action on Sendpoll command

### DIFF
--- a/.changeset/green-onions-knock.md
+++ b/.changeset/green-onions-knock.md
@@ -1,0 +1,5 @@
+---
+"@minima-global/mds": patch
+---
+
+fixes types for sendpoll and txnsign

--- a/packages/mds/src/commands/commands.ts
+++ b/packages/mds/src/commands/commands.ts
@@ -361,7 +361,7 @@ export interface SendCommands {
   /**
    * Send function that adds 'send' commands to a list and polls every 30 seconds until the return status is 'true'.
    * @param args - Parameters for sending and polling tokens
-   * @param args.params.action - (Optional) 'list' to show all commands in polling list, 'remove' to remove a command
+   * @param args.params.action - (Optional) 'add' to add a send transaction to the polling queue, 'list' to show all commands in polling list, 'remove' to remove a command
    * @param args.params.uid - (Optional) The uid of a "send" command to remove from polling list. Use with action:remove
    * @param args.params.address - (Optional) A Minima 0x or Mx wallet address or custom script address
    * @param args.params.amount - (Optional) The amount of Minima or custom tokens to send

--- a/packages/mds/src/commands/commands.ts
+++ b/packages/mds/src/commands/commands.ts
@@ -361,7 +361,7 @@ export interface SendCommands {
   /**
    * Send function that adds 'send' commands to a list and polls every 30 seconds until the return status is 'true'.
    * @param args - Parameters for sending and polling tokens
-   * @param args.params.action - (Optional) 'add' to add a send transaction to the polling queue, 'list' to show all commands in polling list, 'remove' to remove a command
+   * @param args.params.action - (Optional) 'add' to add a send transaction to the polling list, 'list' to show all commands in polling list, 'remove' to remove a command
    * @param args.params.uid - (Optional) The uid of a "send" command to remove from polling list. Use with action:remove
    * @param args.params.address - (Optional) A Minima 0x or Mx wallet address or custom script address
    * @param args.params.amount - (Optional) The amount of Minima or custom tokens to send

--- a/packages/mds/src/commands/send/params.ts
+++ b/packages/mds/src/commands/send/params.ts
@@ -68,11 +68,11 @@ export type SendPollParams = SendParams & {
   /**
    * The action to perform.
    */
-  action: 'list' | 'remove';
+  action: 'add' | 'list' | 'remove';
   /**
    * The uid of the transaction to remove.
    */
-  uid: string;
+  uid?: string;
 };
 
 export type SendNoSignParams = {

--- a/packages/mds/src/commands/transactions/params.ts
+++ b/packages/mds/src/commands/transactions/params.ts
@@ -132,7 +132,7 @@ export type TxnSignParams = {
   id: string;
   publickey: string | 'auto';
   txnpostauto?: 'true' | 'false';
-  txnpostburn?: 'true' | 'false';
+  txnpostburn?: string;
   txnpostmine?: 'true' | 'false';
   txndelete?: 'true' | 'false';
 };


### PR DESCRIPTION
Description:
- `txnpostburn` type on `txnsign` was boolean instead of string
- Added missing `action:add` on sendpoll command, make uid optional as this isn't required when adding a send transaction to the queue (uid is automatically generated)